### PR TITLE
Make code compile with recent boost and g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,19 @@
 ######### GENERAL OPTIONS FOR USER #########
 
 # change to icpc for Intel
-CXX = clang++
-MPICXX = mpiicpc
+CXX = g++
+MPICXX = mpic++
 export CXX
 export MPICXX
 
 # BOOST include directory
-#BOOSTINCLUDE = /home/sharma/apps/forServer/boost_1_53_0_mt/boost_1_53_0/
-#BOOSTINCLUDE = /home/sharma/apps/boost/boost_1_55_0/
-BOOSTINCLUDE = /opt/local/include
+#BOOSTDIR=/software/StackBlock/boost_1_58_0/HRL_INSTALL
+#BOOSTINCLUDE = ${BOOSTDIR}/include
+BOOSTDIR=/usr/lib
+BOOSTINCLUDE =/usr/include
 
 # set to yes if using BOOST version >= 1.56.0
-USE_BOOST56 = no
+USE_BOOST56 = yes
 ifeq ($(USE_BOOST56), yes)
 	B56 = -DBOOST_1_56_0
 endif
@@ -26,10 +27,13 @@ endif
 #BOOSTLIB = -L/home/sharma/apps/forServer/boost_1_53_0_mt/boost_1_53_0/stage/lib -lboost_serialization -lboost_system -lboost_filesystem
 #BOOSTLIB = -L/home/sharma/apps/boost/boost_1_55_0/stage/lib -lboost_serialization -lboost_system -lboost_filesystem 
 #BOOSTLIB = -lboost_serialization -lboost_system -lboost_filesystem
-BOOSTLIB = -L/opt/local/lib  -lboost_system-mt -lboost_filesystem-mt -lboost_serialization-mt
+#BOOSTLIB = -L${BOOSTDIR}/lib -lboost_system-mt -lboost_filesystem-mt -lboost_serialization-mt
+# Note: Newer boost libraries are typically thread-safe => "-mt" suffix not required. 
+BOOSTLIB = -L${BOOSTDIR}/lib -lboost_system -lboost_filesystem -lboost_serialization
 
 #LAPACKBLAS = -lblas -llapack
-LAPACKBLAS =    /usr/lib/liblapack.dylib /usr/lib/libblas.dylib
+#LAPACKBLAS =    /usr/lib/liblapack.dylib /usr/lib/libblas.dylib
+LAPACKBLAS = 
 
 # set if we will use MPI or OpenMP
 USE_MPI = no
@@ -39,9 +43,9 @@ OPENMP = no
 USE_MKL = no
 
 ifeq ($(USE_MKL), yes)
-MKLLIB = .
-LAPACKBLAS = -L${MKLLIB} -lmkl_gf_lp64 -lmkl_sequential -lmkl_core #-lrt #-liomp5 
-MKLFLAGS = /usr/local/server/IntelStudio_2015/mkl/include/
+# LAPACKBLAS = -L${MKLLIB} -lmkl_gf_lp64 -lmkl_sequential -lmkl_core #-lrt #-liomp5 
+LAPACKBLAS = -Wl,--no-as-needed -L${MKLROOT}/lib/intel64 -lmkl_gf_lp64 -lmkl_core -lmkl_sequential -lm -ldl -lrt
+MKLFLAGS = ${MKLROOT}/include
 MKLOPT = -D_HAS_INTEL_MKL
 else
 MKLFLAGS = .
@@ -132,7 +136,7 @@ ifeq (g++, $(CXX))
 	#endif
    endif
 # GNU compiler
-   OPT = -DNDEBUG -O2 -g -funroll-loops -Werror
+   OPT = -DNDEBUG -O2 -g -funroll-loops -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always
 #   OPT = -g -pg
 endif
 
@@ -263,7 +267,7 @@ $(NEWMATLIB)/libnewmat.a :
 	cd $(NEWMATLIB) && $(MAKE) -f makefile libnewmat.a
 
 clean:
-	rm *.o include/*.o modules/generate_blocks/*.o modules/onepdm/*.o modules/twopdm/*.o modules/npdm/*.o $(NEWMATLIB)*.o libqcdmrg.a libqcdmrg.so $(EXECUTABLE) $(NEWMATLIB)/libnewmat.a genetic/gaopt genetic/*.o btas/lib/*.o btas/lib/libbtas.a modules/two_index_ops/*.o modules/three_index_ops/*.o modules/four_index_ops/*.o modules/ResponseTheory/*.o modules/nevpt2/*.o molcas/*.o modules/mps_nevpt/*o
+	rm -f *.o include/*.o modules/generate_blocks/*.o modules/onepdm/*.o modules/twopdm/*.o modules/npdm/*.o $(NEWMATLIB)*.o libqcdmrg.a libqcdmrg.so $(EXECUTABLE) $(NEWMATLIB)/libnewmat.a genetic/gaopt genetic/*.o btas/lib/*.o btas/lib/libbtas.a modules/two_index_ops/*.o modules/three_index_ops/*.o modules/four_index_ops/*.o modules/ResponseTheory/*.o modules/nevpt2/*.o molcas/*.o modules/mps_nevpt/*o
 	find . -name "*.o" |xargs rm
 check-syntax:
 	$(CXX) $(FLAGS) $(OPT) -o nul -S -Wall -Wextra -pedantic -fsyntax-only -Wno-variadic-macros $(CHK_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ $(NEWMATLIB)/libnewmat.a :
 
 clean:
 	rm -f *.o include/*.o modules/generate_blocks/*.o modules/onepdm/*.o modules/twopdm/*.o modules/npdm/*.o $(NEWMATLIB)*.o libqcdmrg.a libqcdmrg.so $(EXECUTABLE) $(NEWMATLIB)/libnewmat.a genetic/gaopt genetic/*.o btas/lib/*.o btas/lib/libbtas.a modules/two_index_ops/*.o modules/three_index_ops/*.o modules/four_index_ops/*.o modules/ResponseTheory/*.o modules/nevpt2/*.o molcas/*.o modules/mps_nevpt/*o
-	find . -name "*.o" |xargs rm
+	find . -name "*.o" |xargs rm -f
 check-syntax:
 	$(CXX) $(FLAGS) $(OPT) -o nul -S -Wall -Wextra -pedantic -fsyntax-only -Wno-variadic-macros $(CHK_SOURCES)
 # DO NOT DELETE

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,15 @@
 ######### GENERAL OPTIONS FOR USER #########
 
 # change to icpc for Intel
+#CXX = clang++
+#MPICXX = mpiicpc
 CXX = g++
 MPICXX = mpic++
 export CXX
 export MPICXX
 
 # BOOST include directory
-#BOOSTDIR=/software/StackBlock/boost_1_58_0/HRL_INSTALL
+#BOOSTDIR=/software/StackBlock/boost_1_58_0
 #BOOSTINCLUDE = ${BOOSTDIR}/include
 BOOSTDIR=/usr/lib
 BOOSTINCLUDE =/usr/include

--- a/dmrg_tests/runtest
+++ b/dmrg_tests/runtest
@@ -1,6 +1,8 @@
 #change this depending on your architechture
 #MPICOMMAND=srun
-MPICOMMAND="mpirun -np 4"
+#MPICOMMAND="mpirun -np 2"
+MPICOMMAND=""
+PYTHONCOMMAND="python2"
 
 
 
@@ -9,56 +11,56 @@ MPICOMMAND="mpirun -np 4"
 echo "testing energy for c2_d2h..."
 cd c2_d2h
 $MPICOMMAND ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 2  1.0e-6 -75.4844085040 -74.9778423596
+$PYTHONCOMMAND ../test_energy.py 2  1.0e-6 -75.4844085040 -74.9778423596
 
 echo "testing 2-pdm for c2_d2h..."
-python ../test_twopdm.py spat_twopdm.0.0.txt node0/spatial_twopdm.0.0.txt 1e-7
-python ../test_twopdm.py spat_twopdm.1.1.txt node0/spatial_twopdm.1.1.txt 1e-7
+$PYTHONCOMMAND ../test_twopdm.py spat_twopdm.0.0.txt node0/spatial_twopdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_twopdm.py spat_twopdm.1.1.txt node0/spatial_twopdm.1.1.txt 1e-7
 cd ../
 
 #this just tests the lowest energy calculation. The run here uses no symmetry
 echo "performing energy test on h2o..."
 cd h2o_nosym
 $MPICOMMAND  ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 1  1.0e-6 -76.11460447
+$PYTHONCOMMAND ../test_energy.py 1  1.0e-6 -76.11460447
 cd ../
 
 #test for hubbard model and also calculate the onepdm
 echo "performing reorder, 1-pdm test on hubbard..."
 cd hubbard
 $MPICOMMAND   ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 1  1.0e-6 -6.56819216
-python ../test_onepdm.py spat_onepdm.0.0.txt node0/spatial_onepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_energy.py 1  1.0e-6 -6.56819216
+$PYTHONCOMMAND ../test_onepdm.py spat_onepdm.0.0.txt node0/spatial_onepdm.0.0.txt 1e-7
 cd ../
 
 echo "performing nonspinadapted test on hubbard..."
 cd hubbard_nospin
 $MPICOMMAND   ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 1  1.0e-6 -6.56819216
-python ../test_onepdm.py spat_onepdm.0.0.txt node0/spatial_onepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_energy.py 1  1.0e-6 -6.56819216
+$PYTHONCOMMAND ../test_onepdm.py spat_onepdm.0.0.txt node0/spatial_onepdm.0.0.txt 1e-7
 cd ../
 
 echo "performing heisenberg test..."
 cd heisenberg_2d
 $MPICOMMAND   ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 1  1.0e-6 -11.2284830996
+$PYTHONCOMMAND ../test_energy.py 1  1.0e-6 -11.2284830996
 cd ../
 
 echo "performing bcs test..."
 cd bcs
 #$MPICOMMAND ../../block.spin_adapted dmrg.conf > dmrg.out
 ../../block.spin_adapted dmrg.conf > dmrg.out
-python ../test_energy.py 1  1e-6 -1.4816808342
-python ../test_onepdm.py ref_onepdm.0.0.txt node0/onepdm.0.0.txt 1e-7
-python ../test_onepdm.py spat_pairmat.0.0.txt node0/spatial_pairmat.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_energy.py 1  1e-6 -1.4816808342
+$PYTHONCOMMAND ../test_onepdm.py ref_onepdm.0.0.txt node0/onepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py spat_pairmat.0.0.txt node0/spatial_pairmat.0.0.txt 1e-7
 cd ../
 
 echo "testing transition threepdm..."
 cd threepdm_C2
 $MPICOMMAND ../../block.spin_adapted dmrg.conf > dmrg.out
-python ../test_threepdm.py rdm3_0_0 node0/spatial_threepdm.0.0.txt 1e-6
-python ../test_threepdm.py rdm3_1_0 node0/spatial_threepdm.1.0.txt 1e-6 1
-python ../test_threepdm.py rdm3_1_1 node0/spatial_threepdm.1.1.txt 1e-6 
+$PYTHONCOMMAND ../test_threepdm.py rdm3_0_0 node0/spatial_threepdm.0.0.txt 1e-6
+$PYTHONCOMMAND ../test_threepdm.py rdm3_1_0 node0/spatial_threepdm.1.0.txt 1e-6 1
+$PYTHONCOMMAND ../test_threepdm.py rdm3_1_1 node0/spatial_threepdm.1.1.txt 1e-6 
 cd ../
 
 #this first calculated twopdm with a small M for two lowest states (so the energy is not converged)
@@ -68,17 +70,17 @@ cd ../
 echo "testing energy, 1- and 2-pdm for c2_d2h_smallM..."
 cd c2_d2h_smallM
 $MPICOMMAND ../../block.spin_adapted dmrg.conf >dmrg.out
-python test_twopdm_withe.py 
+$PYTHONCOMMAND test_twopdm_withe.py 
 $MPICOMMAND ../../block.spin_adapted dmrg_fullrestart.conf >dmrg.out
-python test_onepdm_withtwopdm.py 
+$PYTHONCOMMAND test_onepdm_withtwopdm.py 
 cd ../
 
 echo "testing state specific excited states..."
 cd hubbard_stateSpecific
 $MPICOMMAND ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 9  1.0e-6  -2.5065432138	 -2.1684123422	 -2.1684123422	 -1.4755687956	 -1.4755687956	 -1.4142135624  -1.4142135624  -1.2897006828  -0.8284271247 
+$PYTHONCOMMAND ../test_energy.py 9  1.0e-6  -2.5065432138	 -2.1684123422	 -2.1684123422	 -1.4755687956	 -1.4755687956	 -1.4142135624  -1.4142135624  -1.2897006828  -0.8284271247 
 $MPICOMMAND ../../block.spin_adapted dmrg_statespecific.conf >dmrg.out
-python ../test_energy.py 9  1.0e-6  -2.5065432138	 -2.1684123422	 -2.1684123422	 -1.4755687956	 -1.4755687956	 -1.4142135624  -1.4142135624  -1.2897006828  -0.8284271247 
+$PYTHONCOMMAND ../test_energy.py 9  1.0e-6  -2.5065432138	 -2.1684123422	 -2.1684123422	 -1.4755687956	 -1.4755687956	 -1.4142135624  -1.4142135624  -1.2897006828  -0.8284271247 
 cd ../
 
 
@@ -87,15 +89,15 @@ echo "testing 3pdm, 4pdm and npdm nevpt2 for h2o_small"
 cd h2o_npdm
 echo "testing 3pdm..."
 $MPICOMMAND ../../block.spin_adapted dmrg3.conf >dmrg3.out
-python ../test_threepdm.py node0/spatial_threepdm.0.0.txt spat_threepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_threepdm.py node0/spatial_threepdm.0.0.txt spat_threepdm.0.0.txt 1e-7
 #echo "testing 4pdm..."
 #$MPICOMMAND ../../block.spin_adapted dmrg4.conf >dmrg.out
-#python ../test_fourpdm.py node0/spatial_fourpdm.0.0.txt spat_fourpdm.0.0.txt 1e-7
+#$PYTHONCOMMAND ../test_fourpdm.py node0/spatial_fourpdm.0.0.txt spat_fourpdm.0.0.txt 1e-7
 #echo "testing npdm nevpt2..."
 #rm -f partial*bin A16_matrix*txt
 #$MPICOMMAND ../../block.spin_adapted npdm_nevpt.conf >dmrg.out
-#python ../test_threepdm.py node0/A16_matrix.0.0.txt A16_matrix.0.0.txt.ref 1e-7
-#python ../test_threepdm.py node0/A22_matrix.0.0.txt A22_matrix.0.0.txt.ref 1e-7
+#$PYTHONCOMMAND ../test_threepdm.py node0/A16_matrix.0.0.txt A16_matrix.0.0.txt.ref 1e-7
+#$PYTHONCOMMAND ../test_threepdm.py node0/A22_matrix.0.0.txt A22_matrix.0.0.txt.ref 1e-7
 cd ../
 
 
@@ -104,61 +106,61 @@ echo "testing 1pdm and 2pdm in non-spinAdapted calcultions"
 cd hubbard_nonspinpdm
 echo " test 1pdm..."
 $MPICOMMAND ../../block.spin_adapted dmrg_onepdm.conf >dmrg.out
-python ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-7
 echo " test 2pdm..."
 #$MPICOMMAND ../../block.spin_adapted dmrg_twopdm.conf >dmrg.out
 ../../block.spin_adapted dmrg_twopdm.conf >dmrg.out
-python ../test_onepdm.py node0/spatial_twopdm.0.0.txt spat_twopdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_twopdm.0.0.txt spat_twopdm.0.0.txt 1e-7
 cd ../
 
 echo "testing transition 1pdm and 2pdm for hubbard model"
 cd hubbard_transition_pdm
 echo " test transiton 1pdm..."
 $MPICOMMAND ../../block.spin_adapted dmrg_onepdm.conf >dmrg.out
-python ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-7
-python ../test_onepdm.py node0/spatial_onepdm.1.1.txt spat_onepdm.1.1.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.1.1.txt spat_onepdm.1.1.txt 1e-7
 echo " test transition 2pdm..."
 $MPICOMMAND ../../block.spin_adapted dmrg_twopdm.conf >dmrg.out
-python ../test_onepdm.py node0/spatial_twopdm.0.0.txt spat_twopdm.0.0.txt 1e-7
-python ../test_onepdm.py node0/spatial_twopdm.1.1.txt spat_twopdm.1.1.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_twopdm.0.0.txt spat_twopdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_twopdm.1.1.txt spat_twopdm.1.1.txt 1e-7
 cd ../
 
 echo "testing transition 1pdm for h2o"
 cd h2o_transitionpdm
 echo " test transiton 1pdm with state average..."
 $MPICOMMAND ../../block.spin_adapted dmrg_onepdm.conf >dmrg_onepdm.out
-python ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-7
-python ../test_onepdm.py node0/spatial_onepdm.1.1.txt spat_onepdm.1.1.txt 1e-7
-python ../test_transitiononepdm.py node0/spatial_onepdm.1.0.txt spat_onepdm.1.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.1.1.txt spat_onepdm.1.1.txt 1e-7
+$PYTHONCOMMAND ../test_transitiononepdm.py node0/spatial_onepdm.1.0.txt spat_onepdm.1.0.txt 1e-7
 echo " test transiton 1pdm with state specific..."
 $MPICOMMAND ../../block.spin_adapted dmrg_onepdm.conf >dmrg_onepdm.out
 $MPICOMMAND ../../block.spin_adapted dmrg_statespecific.conf >dmrg_statespecific.out
-python ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-6
-python ../test_onepdm.py node0/spatial_onepdm.1.1.txt spat_onepdm.1.1.txt 1e-7
-python ../test_transitiononepdm.py node0/spatial_onepdm.1.0.txt spat_onepdm.1.0.txt 1e-7
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.0.0.txt spat_onepdm.0.0.txt 1e-6
+$PYTHONCOMMAND ../test_onepdm.py node0/spatial_onepdm.1.1.txt spat_onepdm.1.1.txt 1e-7
+$PYTHONCOMMAND ../test_transitiononepdm.py node0/spatial_onepdm.1.0.txt spat_onepdm.1.0.txt 1e-7
 cd ../
 
 #echo "testing NEVPT2 calculations"
 #cd h2o_nevpt2/
 #$MPICOMMAND ../../block.spin_adapted dmrg.conf >dmrg.out
-#python ../test_nevpt2_energy.py Reference.dat 1e-6 
+#$PYTHONCOMMAND ../test_nevpt2_energy.py Reference.dat 1e-6 
 #cd ../
 
 echo "testing MPSPT calculations"
 cd mpspt2
 $MPICOMMAND ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 1 1e-6 -94.6312677977
+$PYTHONCOMMAND ../test_energy.py 1 1e-6 -94.6312677977
 $MPICOMMAND ../../block.spin_adapted compress.conf >compress.out
 $MPICOMMAND ../../block.spin_adapted response.conf >response.out
-python ../test_energy.py 1 5e-4 -0.1488178755
+$PYTHONCOMMAND ../test_energy.py 1 5e-4 -0.1488178755
 cd ../
 
 echo "testing MPSPT_AAAV calculations"
 cd mpspt2aaav
 $MPICOMMAND ../../block.spin_adapted dmrg.conf >dmrg.out
-python ../test_energy.py 1 1e-6 -17.718279624510
+$PYTHONCOMMAND ../test_energy.py 1 1e-6 -17.718279624510
 $MPICOMMAND ../../block.spin_adapted response_aaav.conf >response_aaav.out
-python ../test_energy.py 1 5e-4 -5.3106166331e-02 
+$PYTHONCOMMAND ../test_energy.py 1 5e-4 -5.3106166331e-02 
 cd ../
 
 ./clean

--- a/input.h
+++ b/input.h
@@ -18,7 +18,6 @@ Sandeep Sharma and Garnet K.-L. Chan
 #include "SpinQuantum.h"
 #include "timer.h"
 #include "couplingCoeffs.h"
-#include <boost/tr1/unordered_map.hpp>
 #include "enumerator.h"
 
 namespace SpinAdapted{

--- a/modules/mps_nevpt/mps_nevpt.C
+++ b/modules/mps_nevpt/mps_nevpt.C
@@ -8,7 +8,7 @@ void dmrg(double sweep_tol);
 vector<double> perturber::ZeroEnergy;
 //vector<double> perturber::CoreEnergy;
 
-double readZeroEnergy(){
+void readZeroEnergy(){
   perturber::ZeroEnergy.resize(dmrginp.nroots());
 //  perturber::CoreEnergy.resize(dmrginp.nroots(),0.0);
 

--- a/modules/npdm/externalsort.h
+++ b/modules/npdm/externalsort.h
@@ -7,6 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
 #include <vector> 
 #include <fstream>
 #include <iostream>

--- a/stackopxop.C
+++ b/stackopxop.C
@@ -3252,7 +3252,7 @@ void SpinAdapted::stackopxop::ccd_cxcdcomp(const StackSpinBlock* otherblock, con
 //    }
 //}
 //
-void SpinAdapted::stackopxop::cdd_cxddcomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
+void SpinAdapted::stackopxop::cdd_cxddcomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
 {
   int ilock = 0;
   const StackSpinBlock* loopblock = (otherblock==b->get_leftBlock()) ? b->get_rightBlock() : b->get_leftBlock();
@@ -3289,7 +3289,7 @@ void SpinAdapted::stackopxop::cdd_cxddcomp(const StackSpinBlock* otherblock, boo
     if (deallocate1) op1->deallocate();
 }
 
-void SpinAdapted::stackopxop::cdd_dxcdcomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
+void SpinAdapted::stackopxop::cdd_dxcdcomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
 {
   int ilock = 0;
   const StackSpinBlock* loopblock = (otherblock==b->get_leftBlock()) ? b->get_rightBlock() : b->get_leftBlock();
@@ -3329,7 +3329,7 @@ void SpinAdapted::stackopxop::cdd_dxcdcomp(const StackSpinBlock* otherblock, boo
     if (deallocate1) op1->deallocate();
 }
 
-void SpinAdapted::stackopxop::ccd_dxcccomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
+void SpinAdapted::stackopxop::ccd_dxcccomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
 {
   const StackSpinBlock* loopblock = (otherblock==b->get_leftBlock()) ? b->get_rightBlock() : b->get_leftBlock();
     
@@ -3365,7 +3365,7 @@ void SpinAdapted::stackopxop::ccd_dxcccomp(const StackSpinBlock* otherblock, boo
     if (deallocate1) op1->deallocate();
 }
 
-void SpinAdapted::stackopxop::ccd_cxcdcomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
+void SpinAdapted::stackopxop::ccd_cxcdcomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q)
 {
   int ilock = 0;
   const StackSpinBlock* loopblock = (otherblock==b->get_leftBlock()) ? b->get_rightBlock() : b->get_leftBlock();

--- a/stackopxop.h
+++ b/stackopxop.h
@@ -64,10 +64,10 @@ namespace stackopxop
 
   //**********************************************************************************************************
   
-  void cdd_cxddcomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
-  void cdd_dxcdcomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
-  void ccd_dxcccomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
-  void ccd_cxcdcomp(const StackSpinBlock* otherblock, boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
+  void cdd_cxddcomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
+  void cdd_dxcdcomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
+  void ccd_dxcccomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
+  void ccd_cxcdcomp(const StackSpinBlock* otherblock, const boost::shared_ptr<StackSparseMatrix> & op1, const StackSpinBlock* b, StackWavefunction& c, StackWavefunction* v, const SpinQuantum& q);
   
   //*********************************************************************************
   


### PR DESCRIPTION
The code compiles now with boost 1.69.0 and gcc 9.1.0. 
It still works for gcc 4.8.5 and boost 1.59.0.